### PR TITLE
Fix link to research.microsoft.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Depixelating Pixel Art
 ======================
 
-For my future use, I distilled the [algorithm for depixelating pixel art](http://research.microsoft.com/en-us/um/people/kopf/pixelart/index.html) into its component steps, minus the explanations and figures.
+For my future use, I distilled the [algorithm for depixelating pixel art](https://web.archive.org/web/20150914131222/http://research.microsoft.com/en-us/um/people/kopf/pixelart/index.html) into its component steps, minus the explanations and figures.
 
 General Algorithm
 -----------------


### PR DESCRIPTION
The link to http://research.microsoft.com/en-us/um/people/kopf/pixelart/index.html results in a 404, I'm not sure if it was moved somewhere else, but I updated the link to archive.org which at least works (even the PDF link).
